### PR TITLE
Fix coverage of numba jit compiled functions

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -46,13 +46,13 @@ jobs:
         run: testflo -n 1 -v .
 
       - name: Generate coverage report
-        if: ${{ python-version == 3.9}}
+        if: ${{ matrix.python-version == 3.9}}
         run: |
           export NUMBA_DISABLE_JIT=1
           testflo -n 1 -v --coverage --coverpkg FEMpy .
 
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
-          if: ${{ python-version == 3.9}}
+          if: ${{ matrix.python-version == 3.9}}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -43,11 +43,16 @@ jobs:
         run: pip install -e .[dev]
 
       - name: Run unit tests
+        run: testflo -n 1 -v .
+
+      - name: Generate coverage report
+        if: ${{ python-version == 3.9}}
         run: |
           export NUMBA_DISABLE_JIT=1
           testflo -n 1 -v --coverage --coverpkg FEMpy .
 
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
+          if: ${{ python-version == 3.9}}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -52,7 +52,7 @@ jobs:
           testflo -n 1 -v --coverage --coverpkg FEMpy .
 
       - name: "Upload coverage to Codecov"
+        if: ${{ matrix.python-version == 3.9}}
         uses: codecov/codecov-action@v1
-          if: ${{ matrix.python-version == 3.9}}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -43,7 +43,9 @@ jobs:
         run: pip install -e .[dev]
 
       - name: Run unit tests
-        run: testflo -n 1 -v --coverage --coverpkg FEMpy .
+        run: |
+          export NUMBA_DISABLE_JIT=1
+          testflo -n 1 -v --coverage --coverpkg FEMpy .
 
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1

--- a/Examples/Benchmarks/QuadMeshScaling.py
+++ b/Examples/Benchmarks/QuadMeshScaling.py
@@ -27,7 +27,7 @@ except ModuleNotFoundError:
 
     solverArgs = {}
 import FEMpy as fp
-from numba import jit
+from numba import njit
 import matplotlib.pyplot as plt
 import niceplots
 
@@ -37,26 +37,26 @@ niceplots.setRCParams()
 # ==============================================================================
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def tractionForce(x):
     ft = np.zeros_like(x)
     ft[:, 0] = 1e6
     return ft
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def bodyForce(x):
     fb = np.zeros_like(x)
     fb[:, 1] = 1e6
     return fb
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def warpFunc(x, y):
     return 2.0 * x, (2.0 - x) * y
 
 
-# @jit(nopython=True, cache=True)
+# @njit( cache=True)
 def createGridMesh(nx, ny, warpFunc=None):
     xNodes = np.tile(np.linspace(0.0, 1.0, nx + 1), ny + 1)
     yNodes = np.repeat(np.linspace(0.0, 1.0, ny + 1), nx + 1)

--- a/FEMpy/Element.py
+++ b/FEMpy/Element.py
@@ -17,7 +17,7 @@ import abc
 # External Python modules
 # ==============================================================================
 import numpy as np
-from numba import jit
+from numba import njit
 from scipy.optimize import root
 
 # ==============================================================================
@@ -26,7 +26,7 @@ from scipy.optimize import root
 from .GaussQuad import gaussQuad1d, gaussQuad2d, gaussQuad3d
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def _makeBMat(NPrime, LMats, numStrain, numDim, numNodes):
     numPoints = np.shape(NPrime)[0]
     BMat = np.zeros((numPoints, numStrain, numDim * numNodes))
@@ -37,7 +37,7 @@ def _makeBMat(NPrime, LMats, numStrain, numDim, numNodes):
     return BMat
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def _makeNMat(N, numDim):
     s = np.shape(N)
     numPoints = s[0]
@@ -49,7 +49,7 @@ def _makeNMat(N, numDim):
     return NMat
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def _computeNTFProduct(F, N):
     # Compute N^T fb at each point, it's complicated because things are not the right shape
     nP = np.shape(F)[0]

--- a/FEMpy/LagrangePoly.py
+++ b/FEMpy/LagrangePoly.py
@@ -16,14 +16,14 @@ Lagrange polynomial interpolation
 # External Python modules
 # ==============================================================================
 import numpy as np
-from numba import jit
+from numba import njit
 
 # ==============================================================================
 # Extension modules
 # ==============================================================================
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def LagrangePoly1d(x, n):
     """Compute the values of the 1d Lagrange polynomials at a series of points
 
@@ -48,10 +48,11 @@ def LagrangePoly1d(x, n):
     for m in range(n):
         for i in list(range(m)) + list(range(m + 1, n)):
             N[:, m] *= (xp - xi[i]) / (xi[m] - xi[i])
+    # print("computing lagrange shape funcs")
     return N
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def LagrangePoly1dDeriv(x, n):
     """Compute the derivatives of the 1d Lagrange polynomials at a series of points
 
@@ -76,7 +77,7 @@ def LagrangePoly1dDeriv(x, n):
     return dNdx
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def LagrangePoly2d(x, y, n):
     """Compute the derivatives of the 2d Lagrange polynomials at a series of points in 2d space
 
@@ -108,7 +109,7 @@ def LagrangePoly2d(x, y, n):
     return N
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def LagrangePoly2dDeriv(x, y, n):
     """Compute the derivatives of the 2d Lagrange polynomials at a series of points in 2d space
 

--- a/FEMpy/Mesh.py
+++ b/FEMpy/Mesh.py
@@ -16,7 +16,7 @@ Mesh Utilities
 # External Python modules
 # ==============================================================================
 import numpy as np
-from numba import jit
+from numba import njit
 
 # ==============================================================================
 # Extension modules
@@ -102,7 +102,7 @@ def getEdgesfromNodes(nodes, conn, nodeEls, edgeInds):
     return Elements, Edges
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def computeElementCentroids(nodeCoords, conn):
     """Compute element centroids
 

--- a/FEMpy/Utils.py
+++ b/FEMpy/Utils.py
@@ -16,14 +16,14 @@ FEMpy Utilities
 # External Python modules
 # ==============================================================================
 import numpy as np
-from numba import jit
+from numba import njit
 
 # ==============================================================================
 # Extension modules
 # ==============================================================================
 
 
-@jit(nopython=True, cache=True)
+@njit(cache=True)
 def ksAgg(g, rho=100.0):
     """Compute a smooth approximation to the maximum of a set of values us KS agregation
 


### PR DESCRIPTION
The coverage of jit compiled functions is not correctly captured so I now disable numba jit compilation before generating the coverage report, also switch all instances of the @jit operator to @njit