### PR TITLE
Deprivatise tests

### DIFF
--- a/FEMpy/Element.py
+++ b/FEMpy/Element.py
@@ -170,7 +170,7 @@ class Element:
         N : n x numNode array
             Shape function values, N[i][j] is the value of the jth shape function at the ith point
         """
-        return
+        raise NotImplementedError
 
     @abc.abstractmethod
     def getShapeFunctionDerivs(self, paramCoords):
@@ -191,7 +191,7 @@ class Element:
             Shape function values, N[i][j][k] is the value of the kth shape function at the ith point w.r.t the kth
             parametric coordinate
         """
-        return
+        raise NotImplementedError
 
     def getNPrime(self, paramCoords, nodeCoords):
         """Compute shape function derivatives at a set of parametric coordinates
@@ -418,7 +418,7 @@ class Element:
         nodeCoords : numNode x numDim array
             Node coordinates
         """
-        pass
+        raise NotImplementedError
 
     def testGetParamCoord(self, n=10, maxIter=40, tol=1e-10):
         """Test the getParamCoord method

--- a/FEMpy/Element.py
+++ b/FEMpy/Element.py
@@ -386,11 +386,10 @@ class Element:
         return (Fb.T * detJ).T
 
     # ==============================================================================
-    # Private functions
+    # Functions for testing element implementations
     # ==============================================================================
-
-    # --- Functions for testing element implementations ---
-    def _getRandParamCoord(self, n=1):
+    
+    def getRandParamCoord(self, n=1):
         """Generate a set of random parametric coordinates
 
         By default this method assumes that the valid range for all parametric coordinates is [-1, 1].
@@ -409,7 +408,7 @@ class Element:
         return np.atleast_2d(np.random.rand(n, self.numDim))
 
     @abc.abstractmethod
-    def _getRandomNodeCoords(self):
+    def getRandomNodeCoords(self):
         """Generate a random, but valid, set of node coordinates for an element
 
         This method should be implemented for each element.
@@ -421,7 +420,7 @@ class Element:
         """
         pass
 
-    def _testGetParamCoord(self, n=10, maxIter=40, tol=1e-10):
+    def testGetParamCoord(self, n=10, maxIter=40, tol=1e-10):
         """Test the getParamCoord method
 
         This test works by generating a set of random parametric coordinates, converting them to real coordinates, and
@@ -440,7 +439,7 @@ class Element:
             error[i] = paramCoord[i] - self.getParamCoord(realCoords[i], nodeCoords, maxIter=maxIter, tol=tol)
         return error
 
-    def _testShapeFunctionDerivatives(self, n=10):
+    def testShapeFunctionDerivatives(self, n=10):
         """Test the implementation of the shape function derivatives using the complex-step method
 
         Parameters
@@ -458,7 +457,7 @@ class Element:
             dNApprox[:, i, :] = 1e200 * np.imag(self.getShapeFunctions(coordPert))
         return dN - dNApprox
 
-    def _testShapeFunctionSum(self, n=10):
+    def testShapeFunctionSum(self, n=10):
         """Test the basic property that shape function values should sum to 1 everywhere within an element
 
         Parameters

--- a/FEMpy/Element.py
+++ b/FEMpy/Element.py
@@ -388,7 +388,7 @@ class Element:
     # ==============================================================================
     # Functions for testing element implementations
     # ==============================================================================
-    
+
     def getRandParamCoord(self, n=1):
         """Generate a set of random parametric coordinates
 
@@ -431,8 +431,8 @@ class Element:
         n : int, optional
             Number of random coordinates to generate, by default 10
         """
-        paramCoord = self._getRandParamCoord(n)
-        nodeCoords = self._getRandomNodeCoords()
+        paramCoord = self.getRandParamCoord(n)
+        nodeCoords = self.getRandomNodeCoords()
         realCoords = self.getRealCoord(paramCoord, nodeCoords)
         error = np.zeros_like(realCoords)
         for i in range(n):
@@ -447,7 +447,7 @@ class Element:
         n : int, optional
             Number of random coordinates to generate, by default 10
         """
-        paramCoords = self._getRandParamCoord(n)
+        paramCoords = self.getRandParamCoord(n)
         coordPert = np.zeros_like(paramCoords, dtype="complex128")
         dN = self.getShapeFunctionDerivs(paramCoords)
         dNApprox = np.zeros_like(dN)
@@ -465,7 +465,7 @@ class Element:
         n : int, optional
             Number of points to test at, by default 10
         """
-        paramCoords = self._getRandParamCoord(n)
+        paramCoords = self.getRandParamCoord(n)
         N = self.getShapeFunctions(paramCoords)
         return np.sum(N, axis=1)
 

--- a/FEMpy/Lagrange1dElement.py
+++ b/FEMpy/Lagrange1dElement.py
@@ -83,7 +83,7 @@ class Lagrange1dElement(Element):
     def getMassMat(self, nodeCoords, constitutive, n=None):
         return super().getMassMat(nodeCoords, constitutive, n=n) * constitutive.A
 
-    def _getRandomNodeCoords(self):
+    def getRandomNodeCoords(self):
         """Generate a random, but valid, set of node coordinates for an element
 
         For a 1D element, we simply create evenly spaced points from 0 to one, add some slight random noise and then

--- a/FEMpy/QuadElement.py
+++ b/FEMpy/QuadElement.py
@@ -155,7 +155,7 @@ class QuadElement(Element):
         Fb = self._computeNTFProduct(F, N)
         return (Fb.T * detJStar).T
 
-    def _getRandomNodeCoords(self):
+    def getRandomNodeCoords(self):
         """Generate a random, but valid, set of node coordinates for an element
 
         For the Quad element, we simply create a grid of evenly spaced points then add some random noise to each point

--- a/FEMpy/SerendipityQuad.py
+++ b/FEMpy/SerendipityQuad.py
@@ -146,10 +146,10 @@ class serendipityQuadElement(QuadElement):
         """
         return serendipityShapeFuncDerivs(paramCoords[:, 0], paramCoords[:, 1])
 
-    def _getRandomNodeCoords(self):
+    def getRandomNodeCoords(self):
         """Generate a random, but valid, set of node coordinates for an element
 
-        Here we simply call the _getRandomNodeCoords method of the parent 2nd order QuadElement class and then remove
+        Here we simply call the getRandomNodeCoords method of the parent 2nd order QuadElement class and then remove
         the central point, the points need to be reordered too because the 2nd order QuadElement points are not in CCW
         order as the Serendipity quad points are
 
@@ -158,7 +158,7 @@ class serendipityQuadElement(QuadElement):
         nodeCoords : numNode x numDim array
             Node coordinates
         """
-        nodeCoords = super()._getRandomNodeCoords()
+        nodeCoords = super().getRandomNodeCoords()
         return nodeCoords[[0, 2, 8, 6, 1, 5, 7, 3]]
 
 

--- a/tests/testElements.py
+++ b/tests/testElements.py
@@ -49,15 +49,15 @@ class ElementUnitTest(unittest.TestCase):
         np.random.seed(1)
 
     def testGetParamCoord(self):
-        error = self.element._testGetParamCoord(self.numTestPoints, maxIter=400, tol=self.tol * 1e-3)
+        error = self.element.testGetParamCoord(self.numTestPoints, maxIter=400, tol=self.tol * 1e-3)
         np.testing.assert_allclose(error, 0, atol=self.tol, rtol=self.tol)
 
     def testShapeFunctionDerivatives(self):
-        error = self.element._testShapeFunctionDerivatives(self.numTestPoints)
+        error = self.element.testShapeFunctionDerivatives(self.numTestPoints)
         np.testing.assert_allclose(error, 0, atol=self.tol, rtol=self.tol)
 
     def testShapeFunctionSum(self):
-        sum = self.element._testShapeFunctionSum(self.numTestPoints)
+        sum = self.element.testShapeFunctionSum(self.numTestPoints)
         np.testing.assert_allclose(sum, 1, atol=self.tol, rtol=self.tol)
 
 


### PR DESCRIPTION
Since element unit test functions are called from outside the element class during unit tests, they shouldn't be private functions